### PR TITLE
Remove need to give sender ID when configuring

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -10,7 +10,7 @@
     <option name="myDefaultNotNull" value="android.support.annotation.NonNull" />
     <option name="myNullables">
       <value>
-        <list size="7">
+        <list size="10">
           <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.Nullable" />
           <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nullable" />
           <item index="2" class="java.lang.String" itemvalue="javax.annotation.CheckForNull" />
@@ -18,18 +18,24 @@
           <item index="4" class="java.lang.String" itemvalue="android.support.annotation.Nullable" />
           <item index="5" class="java.lang.String" itemvalue="androidx.annotation.Nullable" />
           <item index="6" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNullable" />
+          <item index="7" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.Nullable" />
+          <item index="8" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableDecl" />
+          <item index="9" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableType" />
         </list>
       </value>
     </option>
     <option name="myNotNulls">
       <value>
-        <list size="6">
+        <list size="9">
           <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.NotNull" />
           <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nonnull" />
           <item index="2" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.NonNull" />
           <item index="3" class="java.lang.String" itemvalue="android.support.annotation.NonNull" />
           <item index="4" class="java.lang.String" itemvalue="androidx.annotation.NonNull" />
           <item index="5" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNonNull" />
+          <item index="6" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.NonNull" />
+          <item index="7" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullDecl" />
+          <item index="8" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullType" />
         </list>
       </value>
     </option>

--- a/src/main/java/com/cloudfiveapp/push/CloudFivePush.kt
+++ b/src/main/java/com/cloudfiveapp/push/CloudFivePush.kt
@@ -50,6 +50,11 @@ private constructor(private val applicationContext: Context,
             }
         }
 
+        /**
+         * Returns true if [CloudFivePush.configure] has been called already.
+         */
+        @Suppress("unused") // Api
+        @JvmStatic
         fun isConfigured(): Boolean {
             return instance != null
         }

--- a/src/main/java/com/cloudfiveapp/push/CloudFivePush.kt
+++ b/src/main/java/com/cloudfiveapp/push/CloudFivePush.kt
@@ -51,6 +51,22 @@ private constructor(private val applicationContext: Context,
         }
 
         /**
+         * Configure CloudFivePush. This should be called from your Application's onCreate method.
+         *
+         * @param context your application's context
+         * @param senderId the Sender ID found in the Firebase console
+         * @param pushMessageReceiver a [PushMessageReceiver] that will handle push notifications
+         * @param devMode sets up push registration to go through CloudFive's dev server
+         */
+        @Suppress("unused", "MemberVisibilityCanBePrivate") // Api
+        @Deprecated("GCM Sender ID is no longer required", ReplaceWith("CloudFivePush.configure(context, pushMessageReceiver, devMode)", "com.cloudfiveapp.push.CloudFivePush"))
+        @JvmStatic
+        @JvmOverloads
+        fun configure(context: Context, senderId: String, pushMessageReceiver: PushMessageReceiver, devMode: Boolean = false) {
+            configure(context, pushMessageReceiver, devMode)
+        }
+
+        /**
          * Returns true if [CloudFivePush.configure] has been called already.
          */
         @Suppress("unused") // Api

--- a/src/main/java/com/cloudfiveapp/push/FCMIntentService.kt
+++ b/src/main/java/com/cloudfiveapp/push/FCMIntentService.kt
@@ -9,7 +9,7 @@ class FCMIntentService : FirebaseMessagingService() {
 
     override fun onNewToken(token: String) {
         super.onNewToken(token)
-        CloudFivePush.onNewToken()
+        CloudFivePush.onNewToken(token)
     }
 
     override fun onMessageReceived(remoteMessage: RemoteMessage) {


### PR DESCRIPTION
https://firebase.google.com/docs/cloud-messaging/android/client

This adds a listener to a Task from the Firebase API.  That listener waits for the task to be complete before getting the token that C5 needs and registering with it.